### PR TITLE
Fixed a bug on Safari, where clicking on tabs did not work.

### DIFF
--- a/js/view_store.js
+++ b/js/view_store.js
@@ -43,8 +43,10 @@
 			this.trigger(this.state);
 		},
 		popHistoryState: function(event) {
-			this.state = event.state;
-			this.trigger(this.state);
+			if(event.state) {
+				this.state = event.state;
+				this.trigger(this.state);
+			}
 		}
 	});
 })();


### PR DESCRIPTION
Safari fires an onpopstate event when the page loads, with a null state.
We were receiving this event, and updating the ViewStore state with it.
This caused an error to be thrown whenever we would subsequently try to
access a property of the state.
