### PR TITLE
Use a vertical button group for week selector in the season schedule.

### DIFF
--- a/css/core.css
+++ b/css/core.css
@@ -15,4 +15,8 @@ img.faction {
    width: auto;
    padding-right: 5px;
    padding-left: 5px;
-}​
+}
+
+#edit-week-button {
+  margin-bottom: 1em;
+}

--- a/js/actions.js
+++ b/js/actions.js
@@ -15,6 +15,7 @@ module.exports = Reflux.createActions([
 	"updateWeek",
 
 	"viewMainTab",
+	"viewWeek",
 	"viewPlayerTab",
 	"viewPlayer",
 	"viewRenamedPlayer",

--- a/js/components/conference_container.js
+++ b/js/components/conference_container.js
@@ -58,7 +58,7 @@ var ConferenceTable = React.createClass({
 		return (
 			<div>
 				<PageHeader>{this.props.conference.Name}</PageHeader>
-				<Grid>
+				<Grid fluid>
 					<Row>{rows}</Row>
 				</Grid>
 			</div>

--- a/js/components/player_container.js
+++ b/js/components/player_container.js
@@ -38,25 +38,23 @@ var PlayerSchedule = React.createClass({
 			});
 		}
 		return (
-			<Grid>
-				<Row>
-					<Col xs={12}>
-						<Table striped bordered condensed hover>
-							<thead>
-								<tr>
-									<td>Week</td>
-									<td>Opponent</td>
-									<td>Scenario</td>
-									<td>Winner</td>
-								</tr>
-							</thead>
-							<tbody>
-								{rows}
-							</tbody>
-						</Table>
-					</Col>
-				</Row>
-			</Grid>
+			<Row>
+				<Col xs={12}>
+					<Table striped bordered condensed hover>
+						<thead>
+							<tr>
+								<td>Week</td>
+								<td>Opponent</td>
+								<td>Scenario</td>
+								<td>Winner</td>
+							</tr>
+						</thead>
+						<tbody>
+							{rows}
+						</tbody>
+					</Table>
+				</Col>
+			</Row>
 		);
 	}
 });
@@ -107,17 +105,15 @@ var PlayerInjuries = React.createClass({
 			);
 		}
 		return (
-			<Grid>
-				<Row>
-					<Col xs={this.props.admin? 6 : 12}>
-						<Table striped bordered condensed hover>
-							<thead><th>Injuries</th></thead>
-							<tbody>{rows}</tbody>
-						</Table>
-					</Col>
-					{adminCols}
-				</Row>
-			</Grid>
+			<Row>
+				<Col xs={this.props.admin? 6 : 12}>
+					<Table striped bordered condensed hover>
+						<thead><th>Injuries</th></thead>
+						<tbody>{rows}</tbody>
+					</Table>
+				</Col>
+				{adminCols}
+			</Row>
 		);
 	}
 });
@@ -192,25 +188,23 @@ var PlayerBonds = React.createClass({
 			);
 		}
 		return (
-			<Grid>
-				<Row>
-					<Col xs={this.props.admin? 6 : 12}>
-						<Table striped bordered hover >
-							<thead>
-								<th>Warcaster/Warlock</th>
-								<th>Warjack/Warbeast</th>
-								<th>Bond Name</th>
-								<th>Bond Number</th>
-								{adminHeader}
-							</thead>
-							<tbody>
-								{bonds}
-								{editingPanel}
-							</tbody>
-						</Table>
-					</Col>
-				</Row>
-			</Grid>
+			<Row>
+				<Col xs={this.props.admin? 6 : 12}>
+					<Table striped bordered hover >
+						<thead>
+							<th>Warcaster/Warlock</th>
+							<th>Warjack/Warbeast</th>
+							<th>Bond Name</th>
+							<th>Bond Number</th>
+							{adminHeader}
+						</thead>
+						<tbody>
+							{bonds}
+							{editingPanel}
+						</tbody>
+					</Table>
+				</Col>
+			</Row>
 		);
 	}
 });
@@ -290,24 +284,22 @@ var PlayerPotentialBonds = React.createClass({
 			);
 		}
 		return (
-			<Grid>
-				<Row>
-					<Col xs={12}>
-						<Table striped bordered hover >
-							<thead>
-								<th>Warcaster/Warlock</th>
-								<th>Warjack/Warbeast</th>
-								<th>Bonus</th>
-								{adminHeader}
-							</thead>
-							<tbody>
-								{bonds}
-								{editingPanel}
-							</tbody>
-						</Table>
-					</Col>
-				</Row>
-			</Grid>
+			<Row>
+				<Col xs={12}>
+					<Table striped bordered hover >
+						<thead>
+							<th>Warcaster/Warlock</th>
+							<th>Warjack/Warbeast</th>
+							<th>Bonus</th>
+							{adminHeader}
+						</thead>
+						<tbody>
+							{bonds}
+							{editingPanel}
+						</tbody>
+					</Table>
+				</Col>
+			</Row>
 		);
 	}
 });
@@ -385,7 +377,7 @@ module.exports = React.createClass({
 			<p>No player selected.</p>;
 
 		return (
-			<Grid id="player-info">
+			<Grid id="player-info" fluid>
 				<Row>
 					<PlayerSelector players={players} selectedPlayer={this.props.selectedPlayer} />
 					{playerInfo}

--- a/js/components/season.js
+++ b/js/components/season.js
@@ -33,12 +33,17 @@ module.exports = React.createClass({
 		this.setState({ season: season, activeWeek: season.Weeks[0] });
 	},
 	view: function(state: Object) {
+		var oldActiveWeek = this.state.activeWeek;
 		this.setState({
 			activeKey: state.mainTab,
 			selectedPlayer: this.getPlayer(state.playerName),
 			activePlayerTab: state.playerTab,
 			activeWeek: this.state.season.Weeks[state.weekNumber - 1],
 		});
+		if (oldActiveWeek != this.state.activeWeek &&
+			this.state.activeKey == 1) {
+				this.refs.seasonSchedule.scrollToSchedule();
+		}
 	},
 	getPlayer: function(playerName: string): ?Object {
 		for (var i = 0; i < this.state.season.Players.length; i++) {
@@ -51,7 +56,8 @@ module.exports = React.createClass({
 		var admin = $('#season-schedule').data('admin');
 		var season = this.state.season;
 		if(season) {
-			var content = <SeasonScheduleContainer admin={admin}
+			var content = <SeasonScheduleContainer ref="seasonSchedule"
+				admin={admin}
 				season={season}
 				activeWeek={this.state.activeWeek} />;
 			if (this.state.activeKey == 2)

--- a/js/components/season.js
+++ b/js/components/season.js
@@ -1,6 +1,7 @@
 /* @flow */
 var React = require('react');
 var Reflux = require('reflux');
+var Grid = require('react-bootstrap/Grid');
 var Navbar = require('react-bootstrap/Navbar');
 var NavItem = require('react-bootstrap/NavItem');
 var Nav = require('react-bootstrap/Nav');
@@ -15,11 +16,13 @@ module.exports = React.createClass({
 	mixins: [Reflux.ListenerMixin],
 	getInitialState: function() {
 		var selectedPlayer: ?Object = null;
+		var season = SeasonStore.season;
 		return {
-			season: SeasonStore.season,
+			season: season,
 			activeKey: 1,
 			selectedPlayer: selectedPlayer,
-			activePlayerTab: 1
+			activePlayerTab: 1,
+			activeWeek: season && season.Weeks[0],
 		};
 	},
 	componentDidMount: function() {
@@ -27,13 +30,14 @@ module.exports = React.createClass({
 		this.listenTo(SeasonStore, this.onSeasonChange);
 	},
 	onSeasonChange: function(season: Object) {
-		this.setState({ season: season });
+		this.setState({ season: season, activeWeek: season.Weeks[0] });
 	},
 	view: function(state: Object) {
 		this.setState({
 			activeKey: state.mainTab,
 			selectedPlayer: this.getPlayer(state.playerName),
-			activePlayerTab: state.playerTab
+			activePlayerTab: state.playerTab,
+			activeWeek: this.state.season.Weeks[state.weekNumber - 1],
 		});
 	},
 	getPlayer: function(playerName: string): ?Object {
@@ -47,14 +51,20 @@ module.exports = React.createClass({
 		var admin = $('#season-schedule').data('admin');
 		var season = this.state.season;
 		if(season) {
-			var content = <SeasonScheduleContainer admin={admin} season={season} />;
+			var content = <SeasonScheduleContainer admin={admin}
+				season={season}
+				activeWeek={this.state.activeWeek} />;
 			if (this.state.activeKey == 2)
 				content = <ConferenceContainer admin={admin} season={season} />;
 			if (this.state.activeKey == 3)
-				content = <PlayerContainer admin={admin} season={season} selectedPlayer={this.state.selectedPlayer} activeTab={this.state.activePlayerTab} />;
+				content = <PlayerContainer
+					admin={admin}
+					season={season}
+					selectedPlayer={this.state.selectedPlayer}
+					activeTab={this.state.activePlayerTab} />;
 			return (
 				<div>
-					<Navbar className="main-nav">
+					<Navbar staticTop fluid>
 						<Nav>
 							<NavItem className={this.state.activeKey == 1 ? "active" : ""}
 									eventKey={1}
@@ -75,7 +85,9 @@ module.exports = React.createClass({
 							</NavItem>
 						</Nav>
 					</Navbar>
-					{content}
+					<Grid fluid>
+						{content}
+					</Grid>
 				</div>
 			);
 		} else {

--- a/js/components/season_schedule_container.js
+++ b/js/components/season_schedule_container.js
@@ -96,6 +96,9 @@ var WeekGroup = React.createClass({
 	hideEditor: function() {
 		this.setState({showWeekEditor: false});
 	},
+	scrollToSchedule: function() {
+		this.refs.weekGroup.getDOMNode().scrollIntoView();
+	},
 	render: function() {
 		var admin = this.props.admin;
 		var number = this.props.week.Number;
@@ -138,7 +141,7 @@ var WeekGroup = React.createClass({
 			}
 		}
 		return (
-			<div>
+			<div ref="weekGroup">
 				{weekEdit}
 				<WeekTable week={this.props.week} admin={this.props.admin} />
 			</div>
@@ -151,6 +154,10 @@ module.exports = React.createClass({
 		season: React.PropTypes.object.isRequired,
 		admin: React.PropTypes.bool,
 		activeWeek: React.PropTypes.object,
+	},
+	// scroll to the schedule. useful when the schedule is below the button group, when the display width is small
+	scrollToSchedule: function() {
+		this.refs.weekGroup.scrollToSchedule();
 	},
 	render: function(): ?ReactElement {
 		var admin = this.props.admin;
@@ -183,7 +190,7 @@ module.exports = React.createClass({
 						</ButtonGroup>
 					</Col>
 					<Col sm={10} xs={12}>
-						<WeekGroup week={this.props.activeWeek} admin={admin} />
+						<WeekGroup ref="weekGroup" week={this.props.activeWeek} admin={admin}  />
 					</Col>
 				</Row>
 			</div>

--- a/js/stores/view.js
+++ b/js/stores/view.js
@@ -5,13 +5,14 @@ var AppActions = require('../actions.js');
 // keeps track of what is being displayed for the main tab set, the player tab set, and the player select box
 module.exports = Reflux.createStore({
 	init: function() {
-		this.state = {mainTab: 1, playerTab: 1, playerName: null};
+		this.state = {mainTab: 1, playerTab: 1, playerName: null, weekNumber: 1};
 		this.historyEnabled = window.history && window.history.pushState;
 		if(this.historyEnabled) {
 			window.onpopstate = AppActions.popHistoryState;
 			window.history.replaceState(this.state, '');
 		}
 		this.listenTo(AppActions.viewMainTab, this.viewMainTab);
+		this.listenTo(AppActions.viewWeek, this.viewWeek);
 		this.listenTo(AppActions.viewPlayerTab, this.viewPlayerTab);
 		this.listenTo(AppActions.viewPlayer, this.viewPlayer);
 		this.listenTo(AppActions.viewRenamedPlayer, this.viewRenamedPlayer);
@@ -19,6 +20,11 @@ module.exports = Reflux.createStore({
 	},
 	viewMainTab: function(key) {
 		this.state.mainTab = key;
+		if(this.historyEnabled) window.history.pushState(this.state, '');
+		this.trigger(this.state);
+	},
+	viewWeek: function(weekNumber) {
+		this.state.weekNumber = weekNumber;
 		if(this.historyEnabled) window.history.pushState(this.state, '');
 		this.trigger(this.state);
 	},


### PR DESCRIPTION
Instead of the accordion UI for weeks in the season schedule, only show one week and use a vertical button group to navigate between the weeks.

This results in faster render time, and it's easier to get to a different week.

Also includes some other UI tweaks:
1) uses a fluid grid to use up the entire width available at all viewport widths
2) added a panel around the week edit form
3) only display the week edit form after an "Edit Week" button is clicked
