### PR TITLE
week timezone fix

### DIFF
--- a/src/admin/api.go
+++ b/src/admin/api.go
@@ -419,7 +419,7 @@ func updateWeek(w http.ResponseWriter, r *http.Request, seasonId string, weekNum
 	if playDate == "" {
 		playDateTime = nil
 	} else {
-		playDateTimeP, err := time.Parse("2006-01-02", playDate)
+		playDateTimeP, err := time.Parse("2006-01-02 -0700 MST", playDate + " -0700 MST")
 		playDateTime = &playDateTimeP
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Fixed a bug where the week date would be incorrect for certain hours of the day.

Unfortunately, the fix includes a hard-coded timezone of MST.
This ought to be fixed at some point.