### PR TITLE
Skip unecessary javascript files in the GAE deploy.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -28,4 +28,5 @@ skip_files:
 - ^(.*/)?.*/RCS/.*$
 - ^(.*/)?\..*$
 - ^/?node_modules/.*$
-
+- ^/?js/(components/|stores/)
+- ^/?js/[^/]*\.js


### PR DESCRIPTION
Taught GAE deploy to ignore js/*.js, js/components, and js/stores, as those contain the original javascript source instead of the built source.