### PR TITLE
Dispute Deadlines

### DIFF
--- a/js/components/season_schedule_container.js
+++ b/js/components/season_schedule_container.js
@@ -26,7 +26,8 @@ var GameRow = React.createClass({
 			player1: game && game.Players[0] && game.Players[0].Name,
 			player2: game && game.Players[1] && game.Players[1].Name,
 			winner: game && game.Winner,
-			isDisputed: game && game.IsDisputed
+			isDisputed: game && game.IsDisputed,
+			disputeDeadline: game && game.DisputeDeadline
 		};
 	},
 	addGame: function(weekNumber, gameIndex, admin) {
@@ -180,10 +181,12 @@ var GameRow = React.createClass({
 			} else {
 				// Displays when a winner already exists
 				winnerMenu = <td><PlayerCell player={this.state.winner} /></td>;
+				var nowSeconds = Date.now()/1000;
+				
 				if(this.state.isDisputed){
 					updateButton = 
 						<td className="game-buttons"><Button bsStyle="danger">Disputed</Button></td>;
-				} else {
+				} else if(this.state.disputeDeadline > nowSeconds) {
 					updateButton = 
 						<td className="game-buttons">
 							<Button onClick={this.processDispute(this.props.weekNumber, this.props.gameIndex, true)} bsStyle="warning">Dispute</Button>

--- a/src/api/seasons.go
+++ b/src/api/seasons.go
@@ -192,7 +192,7 @@ func updateGameDispute(w http.ResponseWriter, r *http.Request, seasonId string, 
 	`
 	
 	var emailList []string
-	emailList = []string{"dungeongod@gmail.com"}
+	emailList = []string{"dungeongod"+"@"+"gmail"+".com"}
 	
 	msg := &mail.Message{
 			Sender:  "",

--- a/src/model/json_data.go
+++ b/src/model/json_data.go
@@ -27,6 +27,7 @@ type Game struct {
 	PlayerIds []string
 	WinnerId string
 	IsDisputed bool
+	DisputeDeadline int64
 }
 
 type PlayerJson struct {


### PR DESCRIPTION
The first time a winner is added to a game, the server sets a four-day deadline from the time that the winner was set. Users only see the dispute button while the current time is not past the deadline.

This deadline does not affect games that are already set as disputed after the deadline has passed.
